### PR TITLE
Added (column, row) tuple index and slice/pointer getters

### DIFF
--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -396,3 +396,17 @@ impl From<[[f32; 4]; 4]> for Mat4 {
         ]}
     }
 }
+
+impl std::ops::Index<(usize, usize)> for Mat4 {
+    type Output = f32;
+
+    fn index(&self, (c, r): (usize, usize)) -> &Self::Output {
+        &self.values[cr(c, r)]
+    }
+}
+
+impl std::ops::IndexMut<(usize, usize)> for Mat4 {
+    fn index_mut(&mut self, (c, r): (usize, usize)) -> &mut Self::Output {
+        &mut self.values[cr(c, r)]
+    }
+}

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -325,6 +325,26 @@ impl Mat4 {
 
         res
     }
+
+    /// Returns the underlying values as a slice
+    pub fn as_slice(&self) -> &[f32] {
+        &self.values
+    }
+
+    /// Returns the underlying values as a mutable slice
+    pub fn as_mut_slice(&mut self) -> &mut [f32] {
+        &mut self.values
+    }
+
+    /// Returns the underlying values as a pointer with no size information
+    pub fn as_ptr(&self) -> *const f32 {
+        self.values.as_ptr()
+    }
+
+    /// Returns the underlying values as a mutable pointer with no size information
+    pub fn as_mut_ptr(&mut self) -> *mut f32 {
+        self.values.as_mut_ptr()
+    }
 }
 
 impl_op_ex!(* |a: &Mat4, b: &Mat4| -> Mat4 {


### PR DESCRIPTION
Hi, I like this as a very minimal 3d graphics crate, however there are a few features missing that I would like.

I've added tuple2 indexing so it can use syntax like `res[(1, 2)] = mat[(2,1)]`.

I've also added some methods to turn the matrix into either a slice or pointer in order to be passed to a graphics API like so

`gl.uniform_matrix4fv_with_f32_array(location, false, mat.as_slice())`

I considered adding a `Deref` into slices, but since types can only have one deref, I'm concerned if you had other plans for that.